### PR TITLE
fix: add all labels for a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An example `paths-labeller.yml` file is shown here:
   - "*.pdf"
   - "*.md"
   - "LICENSE"
+  - "PRIVATE.doc"
 - "label4":
   - "*.py"
   - "*.rb"
@@ -29,10 +30,8 @@ An example `paths-labeller.yml` file is shown here:
   - "*.py"
   - "*.rb"
 - "label6":
-  - "folder/**/*.md"
+  - "folder/**/*.txt"
   - "*.doc"
-- "label7":
-  - "*.doc"
-- "label-precedence":
-  - "README.md"
+- "label8":
+  - "script.py"
 ```

--- a/lib/paths-for-labels.js
+++ b/lib/paths-for-labels.js
@@ -6,12 +6,12 @@ module.exports = function(contents) {
 
   const pathsForLabels = yaml.safeLoad(Buffer.from(contents).toString());
 
-  for (const label in pathsForLabels) {
-    if (!pathsForLabels.hasOwnProperty(label)) {
+  for (const index in pathsForLabels) {
+    if (!pathsForLabels.hasOwnProperty(index)) {
       continue;
     }
 
-    const pathsForLabel = pathsForLabels[label];
+    const pathsForLabel = pathsForLabels[index];
 
     const labels = Object.keys(pathsForLabel);
     labels.forEach((label) => {

--- a/lib/paths-for-labels.js
+++ b/lib/paths-for-labels.js
@@ -41,9 +41,26 @@ module.exports = function(contents) {
 
   return {
     for(path) {
-      const result = processGlobs(path, globData);
+      const results = processGlobs(path, globData);
 
-      return result.labels;
+      // plain all labels into one single array
+      let labels = [];
+      for(let i = 0; i < results.length; i++){
+        const result = results[i];
+        const resultLabels = result.labels;
+
+        // if one of the results is an empty array
+        // then this path is in the exclusions labels
+        if (resultLabels && resultLabels.length == 0) {
+          return [];
+        }
+
+        resultLabels.forEach((resultLabel) => {
+          labels.push(resultLabel);
+        });
+      }
+
+      return labels;
     },
   };
 };
@@ -84,6 +101,5 @@ function processGlobs(path, data) {
     };
   }
 
-  // last element takes precedence
-  return result[result.length - 1];
+  return result;
 }

--- a/lib/paths-for-labels.js
+++ b/lib/paths-for-labels.js
@@ -27,10 +27,7 @@ module.exports = function(contents) {
           }
         }
 
-        // do not add empty labels, as this is the marker for excluded paths
-        if (label !== '') {
-          globLabels.push(label);
-        }
+        globLabels.push(label);
 
         globData[glob] = {
           labels: globLabels,
@@ -44,14 +41,12 @@ module.exports = function(contents) {
       const results = processGlobs(path, globData);
 
       // plain all labels into one single array
-      let labels = [];
-      for(let i = 0; i < results.length; i++){
+      const labels = [];
+      for (let i = 0; i < results.length; i++) {
         const result = results[i];
         const resultLabels = result.labels;
 
-        // if one of the results is an empty array
-        // then this path is in the exclusions labels
-        if (resultLabels && resultLabels.length == 0) {
+        if (isExcluded(resultLabels)) {
           return [];
         }
 
@@ -64,6 +59,20 @@ module.exports = function(contents) {
     },
   };
 };
+
+/**
+ * Returns true if the labels array is empty or if it contains the empty label
+ *
+ * @param {*} labels labels for a specific path
+ * @return {*} if the path must be excluded
+ */
+function isExcluded(labels) {
+  if (labels && labels.length == 0) {
+    return true;
+  }
+
+  return labels.includes('');
+}
 
 /**
  * Selects the data for a specific path, that will be matched against a file

--- a/test/paths-for-labels.js
+++ b/test/paths-for-labels.js
@@ -14,6 +14,7 @@ describe('pathsForLabels', () => {
   - "*.pdf"
   - "*.md"
   - "LICENSE"
+  - "PRIVATE.doc"
 - "label4":
   - "*.py"
   - "*.rb"
@@ -23,10 +24,8 @@ describe('pathsForLabels', () => {
 - "label6":
   - "folder/**/*.txt"
   - "*.doc"
-- "label7":
-  - "*.doc"
 - "label8":
-  - "README.doc"`);
+  - "script.py"`);
   });
 
   describe('labels', () => {
@@ -39,21 +38,28 @@ describe('pathsForLabels', () => {
     });
 
     it('returns no labels for a path without labels', () => {
+      expect(labels.for('class.java')).toEqual(['label1', 'label2']);
+    });
+
+    it('returns no labels for a excluded path', () => {
       expect(labels.for('report.pdf')).toEqual([]);
+      expect(labels.for('CONTRIBUTING.md')).toEqual([]);
+      expect(labels.for('LICENSE')).toEqual([]);
+    });
+
+    it('returns no labels for a excluded path even with existing labels', () => {
+      expect(labels.for('PRIVATE.doc')).toEqual([]);
     });
 
     it('returns labels matching any of multiple paths', () => {
       const rubyLabels = labels.for('foo.rb');
-      expect(rubyLabels.includes('label1')).toBe(true);
-      expect(rubyLabels.includes('label2')).toBe(true);
-      expect(rubyLabels.includes('label4')).toBe(true);
-      expect(rubyLabels.includes('label5')).toBe(true);
-      
+      expect(rubyLabels).toEqual(['label1', 'label2', 'label4', 'label5']);
+
       const pythonLabels = labels.for('foo.py');
-      expect(pythonLabels.includes('label1')).toBe(true);
-      expect(pythonLabels.includes('label2')).toBe(true);
-      expect(pythonLabels.includes('label4')).toBe(true);
-      expect(pythonLabels.includes('label5')).toBe(true);
+      expect(pythonLabels).toEqual(['label1', 'label2', 'label4', 'label5']);
+
+      const docLabels = labels.for('SUMMARY.doc');
+      expect(docLabels).toEqual(['label1', 'label2', 'label6']);
     });
 
     it('returns labels from glob patterns', () => {
@@ -68,7 +74,7 @@ describe('pathsForLabels', () => {
     });
 
     it('returns labels without precedence', () => {
-      expect(labels.for('README.doc')).toEqual(['label1','label2','label6','label7','label8']);
+      expect(labels.for('script.py')).toEqual(['label1', 'label2', 'label4', 'label5', 'label8']);
     });
   });
 });

--- a/test/paths-for-labels.js
+++ b/test/paths-for-labels.js
@@ -25,8 +25,8 @@ describe('pathsForLabels', () => {
   - "*.doc"
 - "label7":
   - "*.doc"
-- "label-precedence":
-  - "README.md"`);
+- "label8":
+  - "README.doc"`);
   });
 
   describe('labels', () => {
@@ -44,10 +44,14 @@ describe('pathsForLabels', () => {
 
     it('returns labels matching any of multiple paths', () => {
       const rubyLabels = labels.for('foo.rb');
+      expect(rubyLabels.includes('label1')).toBe(true);
+      expect(rubyLabels.includes('label2')).toBe(true);
       expect(rubyLabels.includes('label4')).toBe(true);
       expect(rubyLabels.includes('label5')).toBe(true);
-
+      
       const pythonLabels = labels.for('foo.py');
+      expect(pythonLabels.includes('label1')).toBe(true);
+      expect(pythonLabels.includes('label2')).toBe(true);
       expect(pythonLabels.includes('label4')).toBe(true);
       expect(pythonLabels.includes('label5')).toBe(true);
     });
@@ -64,11 +68,7 @@ describe('pathsForLabels', () => {
     });
 
     it('returns labels without precedence', () => {
-      expect(labels.for('LICENSE.md')).toEqual([]);
-    });
-
-    it('returns labels with precedence', () => {
-      expect(labels.for('README.md')).toEqual(['label-precedence']);
+      expect(labels.for('README.doc')).toEqual(['label1','label2','label6','label7','label8']);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?
It fixes the labelling algorithm, as it was using an old behavior from CODEOWNERS file implementation. In that one, there was a precedence, so it applied only the last label to a path. And we do not want that here: we want each path to receive as many labels as defined in the YAML file.

Another fixed thing is about exclusions: if a path/glob is defined under the empty label (`""`), the the Probot will understand no label must be applied to it.

## Why is it important?
Let's be consisted with the original design

## Author's checklist
- [x] Existing and new Unit tests are passing
- [x] Added unit tests checking updated behavior