### PR TITLE
feature: add GitHub for drafting a release including changelog

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,34 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          name-template: 'v$NEXT_PATCH_VERSION 🌈'
+          tag-template: 'v$NEXT_PATCH_VERSION'
+          categories:
+            - title: '🚀 Features'
+              labels:
+                - 'feature'
+                - 'enhancement'
+            - title: '🐛 Bug Fixes'
+              labels:
+                - 'fix'
+                - 'bugfix'
+                - 'bug'
+            - title: '🧰 Maintenance'
+              label: 'chore'
+          change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+          template: |
+            ## Changes
+
+            $CHANGES
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What is this PR doing?
It adds a GH action to create a draft release using GitHub API (https://github.com/release-drafter/release-drafter)

## Why is it important?
We want to avoid the boriing task of creating a changelog with every release. Using the proper names in PRs it's possible to automate a changelog, and there a lot of tools out there. The idea of having this in a GH action is to abstract from the tool, and just use the action.