### PR TITLE
fix: Configure release-drafter properly

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,25 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5
-        with:
-          name-template: 'v$NEXT_PATCH_VERSION 🌈'
-          tag-template: 'v$NEXT_PATCH_VERSION'
-          categories:
-            - title: '🚀 Features'
-              labels:
-                - 'feature'
-                - 'enhancement'
-            - title: '🐛 Bug Fixes'
-              labels:
-                - 'fix'
-                - 'bugfix'
-                - 'bug'
-            - title: '🧰 Maintenance'
-              label: 'chore'
-          change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-          template: |
-            ## Changes
-
-            $CHANGES
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?
It moves the release-drafter config to a separate file, as seen in the project: https://github.com/release-drafter/release-drafter/blob/master/.github/release-drafter.yml

## Why is it important?
RTFM