### PR TITLE
fix: capture when the descriptor is not present in the repository

### DIFF
--- a/lib/path-labeller.js
+++ b/lib/path-labeller.js
@@ -14,14 +14,25 @@ module.exports = class PathLabeller {
   /**
    * Retrives a PathsLabeller file from file in the repository
    */
-  async getLabels() {
+  async getLabels(app) {
     const options = Object.assign({
       path: '.github/paths-labeller.yml',
       owner: this.repo.owner,
       repo: this.repo.name,
     });
-    const data = await this.github.repos.getContents(options);
-
+    let data;
+    try {
+      data = await this.github.repos.getContents(options);
+    }
+    catch (err) {
+      app.log.warn(`(${err}) while reading the path-labeller.yml file in the repository. Using an empty one as fallback`);
+      data = {
+        data: {
+          content: ''
+        }
+      };
+    }
+      
     return pathsForLabels(Buffer.from(data.data.content, 'base64').toString());
   }
 
@@ -52,7 +63,11 @@ module.exports = class PathLabeller {
     });
 
     const arr = Array.from(labelsToAdd);
-    app.log.info(`Labels added to the issue: ${arr}`);
+    if (arr && arr.length > 0) {
+      app.log.info(`Labels added to the issue: ${arr}`);
+    } else {
+      app.log.info('No labels will be added to the issue');
+    }
 
     return this.github.issues.addLabels({
       owner: this.repo.owner,


### PR DESCRIPTION
## What does this PR do?
This PR captures the error thrown by the `github.repos.getContent` method when the descriptor file (paths-labeller.yml) is not present in the repository.

In those cases, we will return an empty object, so that the labeller process will assign an empty array of labels to be added to the PR. Therefore, the INFO log will be changed in consequence

We are adding unit tests to cover those scenarios.

## Why is it important?
If a PR is sent to the repository handled by the probot, and the descriptor is not present yet, then probot will throw a runtime exception, which we want to avoid. This situation happens even when the PR is adding the file.

## Checklist
- [x] Existing unit tests pass
- [x] I have added unit tests covering the changes introduced in this PR

## Related issues
- Closes #15 