### PR TITLE
feat: support reading the configuration file from the base ref branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Probot: Paths labeller
 
-> a GitHub App built with [Probot](https://github.com/probot/probot) that adds labels in Pull Requests based on contents of the `paths-labeller.yml` file.
+> a GitHub App built with [Probot](https://github.com/probot/probot) that adds labels in Pull Requests based on contents of the `paths-labeller.yml` file. It will use base-ref's configuration when calculating the labels to add.
 
 ## Usage
 

--- a/lib/path-labeller.js
+++ b/lib/path-labeller.js
@@ -19,6 +19,7 @@ module.exports = class PathLabeller {
       path: '.github/paths-labeller.yml',
       owner: this.repo.owner,
       repo: this.repo.name,
+      ref: this.event.payload.pull_request.base.ref,
     });
     let data;
     try {
@@ -32,7 +33,7 @@ module.exports = class PathLabeller {
         }
       };
     }
-      
+
     return pathsForLabels(Buffer.from(data.data.content, 'base64').toString());
   }
 

--- a/test/path-labeller.js
+++ b/test/path-labeller.js
@@ -45,6 +45,9 @@ describe('PathLabeller', () => {
       payload: {
         pull_request: {
           user: {login: 'test'},
+          base: {
+            ref: 'master',
+          }
         },
         repository: {
           name: 'bar',
@@ -69,6 +72,10 @@ describe('PathLabeller', () => {
   });
 
   describe('getLabels', () => {
+    beforeEach(() => {
+      event.payload.pull_request.base.ref = 'master';
+    });
+
     it('returns a fallback object when paths-labeller.yml is not present', async () => {
       github = {
         repos: {
@@ -76,6 +83,7 @@ describe('PathLabeller', () => {
         },
       };
 
+      event.payload.pull_request.base.ref = '7.x';
       labeller = new PathLabeller(github, event);
 
       const labelsFile = await labeller.getLabels(app);
@@ -88,6 +96,7 @@ describe('PathLabeller', () => {
         owner: 'foo',
         repo: 'bar',
         path: '.github/paths-labeller.yml',
+        ref: '7.x',
       });
     });
 
@@ -112,6 +121,7 @@ describe('PathLabeller', () => {
         owner: 'foo',
         repo: 'bar',
         path: '.github/paths-labeller.yml',
+        ref: 'master',
       });
     });
   });


### PR DESCRIPTION
## What does this PR do?
It reads the configuration file from the base-ref branch of a PR. This behavior
goes against the rule of using project's default branch for security reasons, but
as this bot is not using destructive actions, it only adds labels based on modified
paths, then we can proceed and read the base-ref branch.

The code already supported returning a fallback, empty content for the configuration
file if it was not present, so this PR only configures the probot library to get
the proper file from the proper branch.

## Why is it important?
We want to avoid adding labels in branches without configuration