### PR TITLE
feat: do not add labels if the PR is in draft state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Probot: Paths labeller
 
 > a GitHub App built with [Probot](https://github.com/probot/probot) that adds labels in Pull Requests based on contents of the `paths-labeller.yml` file. It will use base-ref's configuration when calculating the labels to add.
+>
+> This probot will add the labels declared in the descriptor if the pull request is not a draft pull request.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = (app) => {
 
   const events = [
     'pull_request.opened',
+    'pull_request.ready_for_review',
     'pull_request.synchronize',
   ];
   app.log.info('probot-paths-labeller loaded');

--- a/lib/path-labeller.js
+++ b/lib/path-labeller.js
@@ -42,6 +42,17 @@ module.exports = class PathLabeller {
    * @param {*} app Probot application. We need it to get access to its logger
    */
   async label(app) {
+    const isDraft = this.event.payload.pull_request.draft;
+    if (isDraft && isDraft === true) {
+      app.log.info(`The pull request is in draft state: no labels will be added`);
+      return this.github.issues.addLabels({
+        owner: this.repo.owner,
+        repo: this.repo.name,
+        issue_number: this.event.payload.pull_request.number,
+        labels: [],
+      });
+    }
+
     const compare = await this.github.repos.compareCommits(Object.assign({
       base: this.event.payload.pull_request.base.sha,
       head: this.event.payload.pull_request.head.sha,

--- a/test/path-labeller.js
+++ b/test/path-labeller.js
@@ -231,7 +231,7 @@ describe('PathLabeller', () => {
           data: {
             files: [
               {
-                filename: 'LICENSE',
+                filename: 'README.md',
               },
             ],
           },

--- a/test/path-labeller.js
+++ b/test/path-labeller.js
@@ -134,6 +134,7 @@ describe('PathLabeller', () => {
             base: {
               sha: BASE_SHA,
             },
+            draft: false,
             head: {
               sha: HEAD_SHA,
             },
@@ -212,6 +213,35 @@ describe('PathLabeller', () => {
 
       expect(app.log.info).
           toHaveBeenCalledWith('No labels will be added to the issue');
+      expect(github.issues.addLabels).toHaveBeenCalledWith({
+        owner: 'mdelapenya',
+        repo: 'probot-paths-labellers',
+        issue_number: 17,
+        labels: expectedLabels,
+      });
+    });
+
+    it('adds zero labels on draft pull requests', async () => {
+      const expectedLabels = [];
+
+      event.payload.pull_request.draft = true;
+
+      github.repos = {
+        compareCommits: expect.createSpy().andReturn(Promise.resolve({
+          data: {
+            files: [
+              {
+                filename: 'LICENSE',
+              },
+            ],
+          },
+        })),
+      };
+
+      await labeller.label(app);
+
+      expect(app.log.info).
+          toHaveBeenCalledWith('The pull request is in draft state: no labels will be added');
       expect(github.issues.addLabels).toHaveBeenCalledWith({
         owner: 'mdelapenya',
         repo: 'probot-paths-labellers',


### PR DESCRIPTION
## What does this PR do?
It checks that the pull request is in the `draft` state, looking the draft value in the pull_request payload. If so, the bot won't continue the execution.

## Why is it important?
The bot wants to be nicea and polite, so it does not want to add labels before a pull request is ready for review.

## Related issues
- Closes #19 