### PR TITLE
fix: use the proper github event

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ module.exports = (app) => {
 
   const events = [
     'pull_request.opened',
-    'pull_request.ready_for_review',
     'pull_request.synchronize',
+    'pull_request_review.submitted',
   ];
   app.log.info('probot-paths-labeller loaded');
 


### PR DESCRIPTION
## What does this PR do?
It uses the proper github event when capturing non-draft PRs

## Why is it important?
Because of this bug, a PR does is in draft and the moved to the Ready for review state won't receive the labels

## Related issues
- Fixes #21